### PR TITLE
fix for use config:cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Add to `config/services.php`:
 ```php
 'odnoklassniki' => [
     'client_id' => env('ODNOKLASSNIKI_ID'),
+    'client_public' => env('ODNOKLASSNIKI_PUBLIC'),
     'client_secret' => env('ODNOKLASSNIKI_SECRET'),
     'redirect' => env('ODNOKLASSNIKI_REDIRECT'),  
 ],

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -2,6 +2,7 @@
 
 namespace JhaoDa\SocialiteProviders\Odnoklassniki;
 
+use Illuminate\Support\Facades\Config;
 use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\User;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
@@ -44,7 +45,7 @@ class Provider extends AbstractProvider implements ProviderInterface
         $params = [
             'format'          => 'json',
             'method'          => 'users.getCurrentUser',
-            'application_key' => env('ODNOKLASSNIKI_PUBLIC'),
+            'application_key' => Config::get('services.odnoklassniki.client_public'),
             'fields'          => 'uid,name,first_name,last_name,birthday,pic190x190,has_email,email'
         ];
 


### PR DESCRIPTION
> If you are using the config:cache command during deployment, you must make sure that you are only calling the env function from within your configuration files, and not from anywhere else in your application.
> 
> If you are calling env from within your application, it is strongly recommended you add proper configuration values to your configuration files and call env from that location instead, allowing you to convert your env calls to config calls.

[Upgrading To 5.2.0 (Caching And Env)](https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0)
[Сonfiguration caching](https://laravel.com/docs/5.4/configuration#configuration-caching)