### PR TITLE
array_get() to Arr::get() for Laravel 6

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -2,6 +2,7 @@
 
 namespace JhaoDa\SocialiteProviders\Odnoklassniki;
 
+use Illuminate\Support\Arr;
 use Laravel\Socialite\Two\ProviderInterface;
 use SocialiteProviders\Manager\OAuth2\User;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
@@ -73,8 +74,8 @@ class Provider extends AbstractProvider implements ProviderInterface
             'id'       => $user['uid'],
             'name'     => $user['name'],
             'nickname' => null,
-            'email'    => array_get($user, 'email'),
-            'avatar'   => array_get($user, 'pic190x190'),
+            'email'    => Arr::get($user, 'email'),
+            'avatar'   => Arr::get($user, 'pic190x190'),
         ]);
     }
 


### PR DESCRIPTION
`array_get()` no longer exists in Laravel 6
https://stackoverflow.com/questions/57884285/laravel-6-call-to-undefined-function-facuz-theme-array-get