### PR TITLE
OAuth authorization url switched from HTTP to HTTPS

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -25,7 +25,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase(
-            'http://connect.ok.ru/oauth/authorize', $state
+            'https://connect.ok.ru/oauth/authorize', $state
         );
     }
 


### PR DESCRIPTION
The code uses OAuth authorization HTTP url "http://connect.ok.ru/oauth/authorize". It is unsafe and it is 2020 year now, it's time to use HTTPS everywhere. 
OK API manual also [recommends](https://apiok.ru/en/ext/oauth/client) this. 
Fixed it.